### PR TITLE
fixing links in a couple places

### DIFF
--- a/public/dist/style.css
+++ b/public/dist/style.css
@@ -8,9 +8,10 @@ h2 {
 
 a {
   text-decoration: none;
-  cursor: pointer; }
+  cursor: pointer;
+  color: #0c1519; }
   a:visited {
-    color: inherit; }
+    color: #0c1519; }
   a:hover {
     color: #4b49c6; }
 
@@ -231,6 +232,10 @@ nav {
     color: #eff5fc; }
     nav a:visited {
       color: #eff5fc; }
+      nav a:visited:hover {
+        color: #ffec5e; }
+    nav a:hover {
+      color: #ffec5e; }
   nav li {
     width: 100px;
     list-style-type: none;

--- a/public/sass/partials/_navigation.scss
+++ b/public/sass/partials/_navigation.scss
@@ -6,6 +6,14 @@ nav {
 
     &:visited {
       color: $alice-blue;
+
+      &:hover {
+        color: $maize;
+      }
+    }
+
+    &:hover {
+      color: $maize;
     }
   }
 

--- a/public/sass/partials/_normalize.css
+++ b/public/sass/partials/_normalize.css
@@ -9,9 +9,10 @@ h2 {
 a {
   text-decoration: none;
   cursor: pointer;
+  color: $eerie-black;
 
   &:visited {
-    color: inherit;
+    color: $eerie-black;
   }
 
   &:hover {


### PR DESCRIPTION
Cleaned up a couple hover states on the main nav and on the Bits themselves, the two main places where links are used.

Links in nav (visited and not visited) have a $maize hover state.
Links on burst  (visited and not visited) have an $ocean-blue hover state. They are $eerie-black by default.

<img width="493" alt="pic 2018-06-13 at 10 54 00 pm" src="https://user-images.githubusercontent.com/4610199/41389074-dbf72722-6f5c-11e8-9924-a464985297b9.png">
<img width="506" alt="pic 2018-06-13 at 10 54 05 pm" src="https://user-images.githubusercontent.com/4610199/41389075-dc01fcf6-6f5c-11e8-94cd-b3ac778deee4.png">
