### PR TITLE
adjust pencil icon to be a bit wider and in a better spot

### DIFF
--- a/public/dist/style.css
+++ b/public/dist/style.css
@@ -117,6 +117,11 @@ textarea {
   -ms-flex-pack: distribute;
       justify-content: space-around; }
 
+.justify-end {
+  -webkit-box-pack: end;
+      -ms-flex-pack: end;
+          justify-content: flex-end; }
+
 .align-items-center {
   -webkit-box-align: center;
       -ms-flex-align: center;
@@ -224,7 +229,7 @@ button, .button {
     background: #6d9dc5; }
 
 .icon svg {
-  width: 20px; }
+  width: 30px; }
 
 nav {
   background: #4b49c6; }

--- a/public/sass/partials/_button.scss
+++ b/public/sass/partials/_button.scss
@@ -16,5 +16,5 @@ button, .button {
 }
 
 .icon svg {
-  width: 20px;
+  width: 30px;
 }

--- a/public/sass/partials/_flex.scss
+++ b/public/sass/partials/_flex.scss
@@ -20,6 +20,10 @@
   justify-content: space-around;
 }
 
+.justify-end {
+  justify-content: flex-end;
+}
+
 .align-items-center {
   align-items: center;
 }

--- a/views/bit.pug
+++ b/views/bit.pug
@@ -6,7 +6,7 @@ block content
   .inner
     .card-wrapper.flex-container-row.justify-center.flex-wrap
       .bit.card.card-full.shaded.spaced.spaced-top.spaced-lg
-        div
+        div.flex-container-row.justify-end
           if user && bit.author.equals(user._id)
             a(class="icon" href=`/bits/${bit._id}/edit`)
               != h.icon('pencil')


### PR DESCRIPTION
Pencil icon is now 30px wide and tucked to the right, like this:

<img width="996" alt="pic 2018-06-13 at 11 07 24 pm" src="https://user-images.githubusercontent.com/4610199/41389393-a0f8f81a-6f5e-11e8-8d3a-96d04d8a2846.png">

