### PR TITLE
added basic overflow hidden to keep mobile from being terrible

### DIFF
--- a/public/dist/style.css
+++ b/public/dist/style.css
@@ -246,7 +246,8 @@ button, .button {
   width: 30px; }
 
 nav {
-  background: #4b49c6; }
+  background: #4b49c6;
+  overflow: hidden; }
   nav a {
     color: #eff5fc; }
     nav a:visited {

--- a/public/sass/partials/_navigation.scss
+++ b/public/sass/partials/_navigation.scss
@@ -1,5 +1,6 @@
 nav {
   background: $ocean-blue;
+  overflow: hidden;
 
   a {
     color: $alice-blue;


### PR DESCRIPTION
All I did was add an overflow: hidden part to the CSS to prevent it from overflowing, which means the UI is still bad, but at least it removes that ugly side scroll.

The longer term solution will be to design a more mobile friendly nav -- but there are still some design improvements I want to make to the nav that should be done before I work on a design for that. So I'm going to tackle those issues now, and revisit the mobile design after they are complete.