### PR TITLE
center text and adjust line height to look good on mobile

### DIFF
--- a/public/dist/style.css
+++ b/public/dist/style.css
@@ -6,7 +6,8 @@ body {
 h1,
 h2,
 h3 {
-  font-family: "Playfair Display"; }
+  font-family: "Playfair Display";
+  line-height: 1.3em; }
 
 h2 {
   font-size: 1.2em;

--- a/public/sass/partials/_normalize.css
+++ b/public/sass/partials/_normalize.css
@@ -6,6 +6,7 @@ h1,
 h2,
 h3 {
   font-family: $primary-font;
+  line-height: 1.3em;
 }
 
 h2 {

--- a/views/bit.pug
+++ b/views/bit.pug
@@ -12,7 +12,7 @@ block content
               != h.icon('pencil')
             div(class="icon delete flex-container-row justify-center align-items-center" data-link=`/bit/delete/${bit._id}`)
               != h.icon('trash-can')
-        h1.flex-container-row.justify-center= bit.name
+        h1.flex-container-row.justify-center.txt-center= bit.name
         h2.flex-container-row.justify-center= bit.author.name
         each line, i in h.processNewLines(bit.content)
           p= line


### PR DESCRIPTION
Text centered, line height adjusted, and it looks dramatically improved on mobile. 
<img width="379" alt="pic 2018-06-15 at 9 47 27 pm" src="https://user-images.githubusercontent.com/4610199/41494731-ba74a220-70e5-11e8-9274-f816b994a2b1.png">
