### PR TITLE
unify padding a bit

### DIFF
--- a/views/mixins/_bitForm.pug
+++ b/views/mixins/_bitForm.pug
@@ -1,7 +1,7 @@
 mixin bitForm(bit = {}, options = { submit: ''})
   .card-wrapper.card.card-full.flex-container-row.justify-center.flex-wrap
-    .bit.card.card-full
-      form(id="bit" action=`/write/${bit._id || ''}` autocomplete="off" onsubmit="this.disabled = true" onclick="this.disabled = true" method="POST" class="card card-full justify-center")
+    .bit.card-full
+      form(id="bit" action=`/write/${bit._id || ''}` autocomplete="off" onsubmit="this.disabled = true" onclick="this.disabled = true" method="POST" class="card-full justify-center")
         div.flex-container-column.align-items-center
           textarea(id="bit-title" name="name" class="txt-center title" placeholder="Write your title here" value=bit.name)= bit.name
         div.flex-container-column.align-items-center.spaced.spaced-top.spaced-md


### PR DESCRIPTION
Forgot to change branches, it's fine. Tweaked classes on Bit form to unify padding a little bit. It does look tighter on desktop, but I'm going to try it out for a bit. Feels nicer on mobile, more effective use of space.