### PR TITLE
adding lock icon, and have a path forward for trusted users

### DIFF
--- a/controllers/bitController.js
+++ b/controllers/bitController.js
@@ -14,11 +14,12 @@ exports.showUserFeedBits = async (req, res, next) => {
   const user = await User.findOne( { slug: req.user.slug } )
 
   const allMyBits = await Bit.find(
-    { author: user._id, private: [true, false] }
+    { author: user._id, privacy: ['trustedUsers', 'onlyMe', 'world'] }
   )
 
+  // TODO This will show all people's public bits, but should also check if the user is one of their trusted users.
   const otherPeoplesPublicBits = await Bit.find(
-    { author: { $ne: user._id }, private: false }
+    { author: { $ne: user._id }, privacy: 'world' }
   )
 
   const bits = [...allMyBits, ...otherPeoplesPublicBits]
@@ -29,7 +30,7 @@ exports.showUserFeedBits = async (req, res, next) => {
 exports.getBits = async (req, res) => {
 
   const bits = await Bit.find(
-    { private: false }
+    { privacy: 'world' }
   )
 
   res.render('bits', { title: 'Welcome to Wrabbit.', bits });

--- a/controllers/bitController.js
+++ b/controllers/bitController.js
@@ -97,7 +97,10 @@ exports.showBitsByGenre = async (req, res) => {
 
 exports.getBitsByAuthor = async (req, res, next) => {
   const user = await User.findOne({ slug: req.params.slug });
-  const bits = await Bit.find({ author: user._id })
+  // TODO if I am considered a trustedUser to this author, show me all their not Only Me bits
+  const bits = await Bit.find(
+    { author: user._id, privacy: 'world' }
+  )
 
   req.user = user;
   req.bits = bits

--- a/models/Bit.js
+++ b/models/Bit.js
@@ -23,9 +23,10 @@ const bitSchema = new mongoose.Schema({
   prompt: {
     type: String
   },
-  private: {
-    type: Boolean,
-    default: true,
+  privacy: {
+    type: String,
+    default: "trustedUsers",
+    enum: ["trustedUsers", "world", "onlyMe"],
     required: 'You need to provide privacy options'
   }
 }, {

--- a/public/dist/App.bundle.js
+++ b/public/dist/App.bundle.js
@@ -111,6 +111,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.expandTextArea = expandTextArea;
 exports.deleteWarning = deleteWarning;
+exports.changePrivacy = changePrivacy;
 
 function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
 
@@ -140,8 +141,34 @@ function deleteWarning() {
   deleteBtns.forEach(function (btn) {
     btn.addEventListener('click', function (e) {
       var confirm = window.confirm('Are you sure you want to delete this Bit? This is permanent.');
-      if (confirm) deleteAndRedirect(e.target.dataset.link);
+      if (confirm) deleteAndRedirect(btn.dataset.link);
     });
+  });
+}
+
+function changePrivacy() {
+  var lockBtns = [].concat(_toConsumableArray(document.querySelectorAll('.lock-item')));
+  var privacyToggle = document.querySelector('#privacy-toggle');
+  var privacyForm = document.querySelector('#privacy-form');
+
+  if (!privacyToggle) return;
+  lockBtns.forEach(function (btn) {
+    btn.addEventListener('click', function (e) {
+      privacyToggle.parentNode.classList.toggle('hidden');
+    });
+  });
+
+  privacyToggle.addEventListener('change', function (e) {
+    privacyForm.value = e.target.value;
+    privacyToggle.parentNode.classList.toggle('hidden');
+
+    if (privacyForm.value !== 'world') {
+      document.querySelector('.lock-open').classList.add('hidden');
+      document.querySelector('.lock-closed').classList.remove('hidden');
+    } else {
+      document.querySelector('.lock-open').classList.remove('hidden');
+      document.querySelector('.lock-closed').classList.add('hidden');
+    }
   });
 }
 
@@ -178,6 +205,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 (0, _lengthSprint2.default)();
 (0, _editorHelpers.expandTextArea)();
 (0, _prompt.prompt)();
+(0, _editorHelpers.changePrivacy)();
 
 /***/ }),
 /* 3 */

--- a/public/dist/style.css
+++ b/public/dist/style.css
@@ -166,6 +166,17 @@ body {
   font-family: "Source Sans Pro";
   font-size: 18px; }
 
+.absolute {
+  position: absolute; }
+
+.relative {
+  position: relative; }
+
+.dropdown {
+  left: 10px;
+  top: 100%;
+  z-index: 1; }
+
 .spaced.spaced-top.spaced-lg {
   margin-top: 20px; }
 

--- a/public/javascripts/bit.js
+++ b/public/javascripts/bit.js
@@ -3,7 +3,7 @@ import 'regenerator-runtime/runtime';
 
 import timedSprint from './modules/timedSprint';
 import lengthSprint from './modules/lengthSprint';
-import { expandTextArea, deleteWarning } from './modules/editorHelpers';
+import { expandTextArea, deleteWarning, changePrivacy } from './modules/editorHelpers';
 import { prompt } from './modules/prompt';
 import { flashClickHandler } from './modules/flash'
 
@@ -13,3 +13,4 @@ timedSprint();
 lengthSprint();
 expandTextArea();
 prompt();
+changePrivacy();

--- a/public/javascripts/modules/editorHelpers.js
+++ b/public/javascripts/modules/editorHelpers.js
@@ -20,7 +20,33 @@ export function deleteWarning() {
   deleteBtns.forEach(btn => {
     btn.addEventListener('click', e => {
       let confirm = window.confirm('Are you sure you want to delete this Bit? This is permanent.')
-      if (confirm) deleteAndRedirect(e.target.dataset.link)
+      if (confirm) deleteAndRedirect(btn.dataset.link)
     })
+  })
+}
+
+export function changePrivacy() {
+  const lockBtns = [...document.querySelectorAll('.lock-item')]
+  const privacyToggle = document.querySelector('#privacy-toggle')
+  const privacyForm = document.querySelector('#privacy-form')
+
+  if (!privacyToggle) return
+  lockBtns.forEach(btn => {
+    btn.addEventListener('click', e => {
+      privacyToggle.parentNode.classList.toggle('hidden')
+    })
+  })
+
+  privacyToggle.addEventListener('change', e => {
+     privacyForm.value = e.target.value
+     privacyToggle.parentNode.classList.toggle('hidden')
+
+     if (privacyForm.value !== 'world') {
+       document.querySelector('.lock-open').classList.add('hidden')
+       document.querySelector('.lock-closed').classList.remove('hidden')
+     } else {
+       document.querySelector('.lock-open').classList.remove('hidden')
+       document.querySelector('.lock-closed').classList.add('hidden')
+     }
   })
 }

--- a/public/sass/partials/_layout.scss
+++ b/public/sass/partials/_layout.scss
@@ -16,3 +16,17 @@ body {
   font-family: $secondary-font;
   font-size: 18px;
 }
+
+.absolute {
+  position: absolute;
+}
+
+.relative {
+  position: relative;
+}
+
+.dropdown {
+  left: 10px;
+  top: 100%;
+  z-index: 1;
+}

--- a/routes/index.js
+++ b/routes/index.js
@@ -10,7 +10,7 @@ const { catchErrors } = require('../handlers/errorHandlers');
 module.exports = router;
 
 router.get('/',
-  catchErrors(bitController.showUserFeedBits), 
+  catchErrors(bitController.showUserFeedBits),
   catchErrors(bitController.getBits)
 );
 router.get('/write', bitController.addBit);
@@ -46,7 +46,6 @@ router.get('/sprint/:mode',
 
 // Authors
 router.get('/author/:slug',
-  authController.isLoggedIn,
   catchErrors(bitController.getBitsByAuthor)
 );
 

--- a/views/bit.pug
+++ b/views/bit.pug
@@ -13,7 +13,7 @@ block content
               != h.icon('pencil')
             +lock(bit.privacy, { hideToggle: true })
         h1.flex-container-row.justify-center.txt-center= bit.name
-        a(href=`/author/${user.slug}`)
+        a(href=`/author/${bit.author.slug}`)
           h2.flex-container-row.justify-center= bit.author.name
         each line, i in h.processNewLines(bit.content)
           p= line

--- a/views/bit.pug
+++ b/views/bit.pug
@@ -1,6 +1,7 @@
 extends layout
 
 include mixins/_bitCard
+include mixins/_lock
 
 block content
   .inner
@@ -10,8 +11,7 @@ block content
           if user && bit.author.equals(user._id)
             a(class="icon flex-container-row justify-center align-items-center" href=`/bits/${bit._id}/edit`)
               != h.icon('pencil')
-            div(class="icon delete flex-container-row justify-center align-items-center" data-link=`/bit/delete/${bit._id}`)
-              != h.icon('trash-can')
+            +lock(bit.privacy, { hideToggle: true })
         h1.flex-container-row.justify-center.txt-center= bit.name
         a(href=`/author/${user.slug}`)
           h2.flex-container-row.justify-center= bit.author.name

--- a/views/mixins/_bitForm.pug
+++ b/views/mixins/_bitForm.pug
@@ -1,5 +1,10 @@
+include _privacy
+include _editIcons
+
 mixin bitForm(bit = {}, options = { submit: ''})
   .card-wrapper.card.card-full.flex-container-row.justify-center.flex-wrap
+    if bit.privacy
+      +editIcons(bit)
     .bit.card.card-full
       form(id="bit" action=`/write/${bit._id || ''}` autocomplete="off" onsubmit="this.disabled = true" onclick="this.disabled = true" method="POST" class="card card-full justify-center")
         div.flex-container-column.align-items-center
@@ -8,6 +13,7 @@ mixin bitForm(bit = {}, options = { submit: ''})
           textarea(id="bit-content" class=`${options.content}` name="content" placeholder="Write your bit here.")= bit.content
         div
           textarea.hidden(id="prompt-submit" name="prompt")
+        input.hidden(id="privacy-form" name="privacy" value=`${bit.privacy || 'trustedUsers'}`)
         div.flex-container-column.align-items-center.spaced.spaced-top.spaced-lg
           button(type="submit" value="Save" class=`button ${options.submit}` ) Save
   div.flex-container-row.justify-center

--- a/yarn.lock
+++ b/yarn.lock
@@ -2767,6 +2767,13 @@ import-lazy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
 
+imports-loader@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/imports-loader/-/imports-loader-0.8.0.tgz#030ea51b8ca05977c40a3abfd9b4088fe0be9a69"
+  dependencies:
+    loader-utils "^1.0.2"
+    source-map "^0.6.1"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"


### PR DESCRIPTION
Big bit improvement!

Now, by default, Bits have three privacy settings:

-Only Me, where the Bit is only viewable by yourself.
-Trusted users, where the Bit is viewable by people you follow
-World, is viewable by everyone

Note: There is currently no way to follow another trusted user, so currently, if a user has a Bit set to Only Me or Trusted Users, the bit will only display for the author; this does lay the groundwork for a future improvement, however.

You can view the Privacy settings for a bit on any bit you own by going to the Bit page and seeing a closed or open Lock Icon. You can change them by going to the Edit page, clicking the icon and choosing your updated setting, then clicking "Save".

UI improvements may come later.