### PR TITLE
ensure that bit urls are not accessible to those who are not trusted

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -17,7 +17,9 @@ router.get('/write', bitController.addBit);
 
 router.get('/bits/:id/edit',catchErrors(bitController.editBit));
 
-router.get(`/bit/:slug`, catchErrors(bitController.getBitBySlug));
+router.get(`/bit/:slug`,
+  catchErrors(bitController.checkBitPrivacySettings),
+  catchErrors(bitController.getBitBySlug));
 
 router.get('/bit/delete/:id', catchErrors(bitController.deleteBit));
 


### PR DESCRIPTION
Fix ensures that a user's ID must match the trusted user's id.

It occurs to me that, maybe, I could extrapolate some of the checking functions into a separate middleware function, as some of these are getting a bit repetitive.