### PR TITLE
add privacy page where users can see all bits organized by privacy

### DIFF
--- a/controllers/privacyController.js
+++ b/controllers/privacyController.js
@@ -1,0 +1,27 @@
+const mongoose = require("mongoose");
+const Bit = mongoose.model("Bit");
+const User = mongoose.model("User");
+
+exports.getMyOnlyMeBits = async (req, res, next) => {
+  const bits = await Bit.find({ author: req.user._id, privacy: 'onlyMe' })
+  req.onlyMeBits = bits
+  next()
+}
+
+exports.getMyTrustedUserBits = async (req, res, next) => {
+  const bits = await Bit.find({ author: req.user._id, privacy: 'trustedUsers' })
+  req.trustedUserBits = bits
+  next()
+}
+
+exports.getMyPublicBits = async (req, res, next) => {
+  const bits = await Bit.find({ author: req.user._id, privacy: 'world' })
+  req.publicBits = bits
+  next()
+}
+
+exports.directToPrivacyPage = async (req, res, next) => {
+  const { onlyMeBits, trustedUserBits, publicBits } = req
+
+  res.render('privateBits', { title: "Bits sorted by privacy", onlyMeBits, trustedUserBits, publicBits })
+}

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const bitController = require('../controllers/bitController');
+const privacyController = require('../controllers/privacyController');
 const userController = require('../controllers/userController');
 const authController = require('../controllers/authController');
 const userDashController = require('../controllers/userDashController');
@@ -15,6 +16,7 @@ router.get('/',
   catchErrors(bitController.showUserFeedBits),
   catchErrors(bitController.bringToHomePage)
 );
+
 router.get('/write', bitController.addBit);
 
 router.get('/bits/:id/edit',catchErrors(bitController.editBit));
@@ -22,6 +24,14 @@ router.get('/bits/:id/edit',catchErrors(bitController.editBit));
 router.get(`/bit/:slug`,
   catchErrors(bitController.checkBitPrivacySettings),
   catchErrors(bitController.getBitBySlug));
+
+router.get(`/bits/privacy`,
+  authController.requiredLogin,
+  catchErrors(privacyController.getMyOnlyMeBits),
+  catchErrors(privacyController.getMyTrustedUserBits),
+  catchErrors(privacyController.getMyPublicBits),
+  catchErrors(privacyController.directToPrivacyPage)
+)
 
 router.get('/bit/delete/:id', catchErrors(bitController.deleteBit));
 

--- a/views/privateBits.pug
+++ b/views/privateBits.pug
@@ -1,0 +1,20 @@
+extends layout
+
+include mixins/_bitCard
+
+block content
+  .inner
+    div.flex-container-column.align-items-center.txt-light-green
+      h1= title
+    div.big-font.spaced.spaced-bottom.spaced-lg.txt-light-green These bits are visible only to you.
+    .card-wrapper.masonry
+      each bit in onlyMeBits
+        +bitCard(bit, user)
+    div.big-font.spaced.spaced-bottom.spaced-lg.txt-light-green These bits are visible to users you Trust.
+    .card-wrapper.masonry
+      each bit in trustedUserBits
+        +bitCard(bit, user)
+    div.big-font.spaced.spaced-bottom.spaced-lg.txt-light-green These bits are visible to the world!
+    .card-wrapper.masonry
+      each bit in publicBits
+        +bitCard(bit, user)


### PR DESCRIPTION
Route added where a user can view bits based on privacy!

Go to /bits/privacy, and you can see how all your bits shake out at a glance.

Will be important for the UI improvements -- this link isn't available anywhere yet, but it will be in the dropdowns for the Trusted users. Should give users a clear way to see who can see what Bits.