### PR TITLE
Privacy toggle update

### DIFF
--- a/controllers/privacyController.js
+++ b/controllers/privacyController.js
@@ -32,6 +32,7 @@ exports.userIsAuthorOfThisBit = async (req, res, next) => {
   if (req.user.id !== bit.author.id) {
     req.flash('success', `You are not authorized to change the setting on this bit.`);
     res.redirect(`/bit/${req.params.slug}`)
+    return
   }
   next()
 }
@@ -52,7 +53,6 @@ exports.updateBitPrivacy = async (req, res, next) => {
     }
   ).exec();
 
-  req.flash('success', `Successfully updated ${bit.name}`);
-  res.redirect(`/bit/${bit.slug}`)
+  res.json(bit)
 
 }

--- a/public/dist/App.bundle.js
+++ b/public/dist/App.bundle.js
@@ -629,8 +629,6 @@ function autosize(el) {
   el.style.height = el.scrollHeight + 'px';
 }
 
-function onFocus(el) {}
-
 function expandTextArea() {
   var textareas = [].concat(_toConsumableArray(document.querySelectorAll('textarea')));
 
@@ -665,27 +663,11 @@ function deleteWarning() {
 
 function changePrivacy() {
   var lockBtns = [].concat(_toConsumableArray(document.querySelectorAll('.lock-item')));
-  var privacyToggle = document.querySelector('#privacy-toggle');
-  var privacyForm = document.querySelector('#privacy-form');
 
-  if (!privacyToggle) return;
   lockBtns.forEach(function (btn) {
     btn.addEventListener('click', function (e) {
-      privacyToggle.parentNode.classList.toggle('hidden');
+      return btn.nextSibling.classList.toggle('hidden');
     });
-  });
-
-  privacyToggle.addEventListener('change', function (e) {
-    privacyForm.value = e.target.value;
-    privacyToggle.parentNode.classList.toggle('hidden');
-
-    if (privacyForm.value !== 'world') {
-      document.querySelector('.lock-open').classList.add('hidden');
-      document.querySelector('.lock-closed').classList.remove('hidden');
-    } else {
-      document.querySelector('.lock-open').classList.remove('hidden');
-      document.querySelector('.lock-closed').classList.add('hidden');
-    }
   });
 }
 

--- a/public/dist/App.bundle.js
+++ b/public/dist/App.bundle.js
@@ -663,10 +663,9 @@ function deleteWarning() {
 
 function changePrivacy() {
   var lockBtns = [].concat(_toConsumableArray(document.querySelectorAll('.lock-item')));
-
   lockBtns.forEach(function (btn) {
-    btn.addEventListener('click', function (e) {
-      return btn.nextSibling.classList.toggle('hidden');
+    return btn.addEventListener('click', function () {
+      return btn.querySelector('.dropdown').classList.toggle('hidden');
     });
   });
 }
@@ -1150,6 +1149,8 @@ var _flash = __webpack_require__(37);
 
 var _sprintHelpers = __webpack_require__(1);
 
+var _apiHelpers = __webpack_require__(39);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 (0, _editorHelpers.deleteWarning)();
@@ -1160,6 +1161,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 (0, _prompt.prompt)();
 (0, _editorHelpers.changePrivacy)();
 (0, _sprintHelpers.loadInExistingBit)();
+(0, _apiHelpers.api)();
 
 /***/ }),
 /* 11 */
@@ -3516,6 +3518,100 @@ function flashClickHandler() {
     }, 3000);
   });
 }
+
+/***/ }),
+/* 38 */,
+/* 39 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var callAPI = function () {
+  var _ref = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee(e) {
+    var _e$target$dataset, url, payloadKey, payloadValue, callback, data;
+
+    return regeneratorRuntime.wrap(function _callee$(_context) {
+      while (1) {
+        switch (_context.prev = _context.next) {
+          case 0:
+            _e$target$dataset = e.target.dataset, url = _e$target$dataset.url, payloadKey = _e$target$dataset.payloadKey, payloadValue = _e$target$dataset.payloadValue, callback = _e$target$dataset.callback;
+            _context.next = 3;
+            return (0, _axios2.default)(url).then(function (response) {
+              return response.data;
+            });
+
+          case 3:
+            data = _context.sent;
+
+            _customAPICallbacks.customCallbackLibrary[callback]({ data: data, element: e.target });
+
+          case 5:
+          case 'end':
+            return _context.stop();
+        }
+      }
+    }, _callee, this);
+  }));
+
+  return function callAPI(_x) {
+    return _ref.apply(this, arguments);
+  };
+}();
+
+exports.api = api;
+
+var _axios = __webpack_require__(15);
+
+var _axios2 = _interopRequireDefault(_axios);
+
+var _customAPICallbacks = __webpack_require__(40);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
+
+function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
+
+function api() {
+  var apiTriggers = [].concat(_toConsumableArray(document.querySelectorAll('.api')));
+  apiTriggers.forEach(function (trigger) {
+    return trigger.addEventListener('click', callAPI);
+  });
+}
+
+/***/ }),
+/* 40 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+var customCallbackLibrary = exports.customCallbackLibrary = {
+  updateLockIcon: function updateLockIcon(options) {
+    var bit = options.data,
+        element = options.element;
+
+    var lockIcon = element.closest('.lock-item');
+    var openLock = lockIcon.querySelector('.lock-open');
+    var closedLock = lockIcon.querySelector('.lock-closed');
+
+    if (bit.privacy === 'world') {
+      openLock.classList.remove('hidden');
+      closedLock.classList.add('hidden');
+    } else {
+      openLock.classList.add('hidden');
+      closedLock.classList.remove('hidden');
+    }
+  }
+};
 
 /***/ })
 /******/ ]);

--- a/public/dist/style.css
+++ b/public/dist/style.css
@@ -176,11 +176,6 @@ body {
 .relative {
   position: relative; }
 
-.dropdown {
-  left: 10px;
-  top: 100%;
-  z-index: 1; }
-
 @media (max-width: 700px) {
   .no-mobile-side-margin {
     margin-left: 0 !important;
@@ -222,6 +217,30 @@ body {
 .spaced.spaced-left.spaced-sm {
   margin-left: 10px; }
 
+.pad.pad-top.pad-lg {
+  padding-top: 20px; }
+
+.pad.pad-top.pad-md {
+  padding-top: 15px; }
+
+.pad.pad-top.pad-sm {
+  padding-top: 10px; }
+
+.pad.pad-top.pad-xs {
+  padding-top: 5px; }
+
+.pad.pad-bottom.pad-lg {
+  padding-bottom: 20px; }
+
+.pad.pad-bottom.pad-md {
+  padding-bottom: 15px; }
+
+.pad.pad-bottom.pad-sm {
+  padding-bottom: 10px; }
+
+.pad.pad-bottom.pad-xs {
+  padding-bottom: 5px; }
+
 .pad.pad-left.pad-lg {
   padding-left: 20px; }
 
@@ -231,6 +250,9 @@ body {
 .pad.pad-left.pad-sm {
   padding-left: 10px; }
 
+.pad.pad-left.pad-xs {
+  padding-left: 5px; }
+
 .pad.pad-right.pad-lg {
   padding-right: 20px; }
 
@@ -239,6 +261,9 @@ body {
 
 .pad.pad-right.pad-sm {
   padding-right: 10px; }
+
+.pad.pad-right.pad-xs {
+  padding-right: 5px; }
 
 .txt-center {
   text-align: center; }
@@ -341,3 +366,18 @@ nav {
     border-radius: 5px;
     font-size: 20px;
     line-height: 25px; }
+
+.dropdown {
+  top: 100%;
+  right: 0;
+  z-index: 1;
+  font-size: .7em;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+  background: #ffec5e;
+  border-radius: 5px;
+  font-family: "Playfair Display"; }
+  .dropdown li {
+    min-width: 150px; }
+    .dropdown li:hover {
+      background: #6d9dc5; }

--- a/public/dist/style.css
+++ b/public/dist/style.css
@@ -102,6 +102,15 @@ textarea {
       -ms-flex-direction: row;
           flex-direction: row; }
 
+.flex-container-row-reverse {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: reverse;
+      -ms-flex-direction: row-reverse;
+          flex-direction: row-reverse; }
+
 .flex-container-column {
   display: -webkit-box;
   display: -ms-flexbox;

--- a/public/javascripts/bit.js
+++ b/public/javascripts/bit.js
@@ -5,8 +5,9 @@ import timedSprint from './modules/timedSprint';
 import lengthSprint from './modules/lengthSprint';
 import { expandTextArea, deleteWarning, changePrivacy } from './modules/editorHelpers';
 import { prompt } from './modules/prompt';
-import { flashClickHandler } from './modules/flash'
-import { loadInExistingBit } from './modules/sprintHelpers'
+import { flashClickHandler } from './modules/flash';
+import { loadInExistingBit } from './modules/sprintHelpers';
+import { api } from './modules/apiHelpers';
 
 deleteWarning()
 flashClickHandler();
@@ -16,3 +17,4 @@ expandTextArea();
 prompt();
 changePrivacy();
 loadInExistingBit();
+api()

--- a/public/javascripts/modules/apiHelpers.js
+++ b/public/javascripts/modules/apiHelpers.js
@@ -1,0 +1,13 @@
+import axios from 'axios'
+import { customCallbackLibrary } from './customAPICallbacks'
+
+async function callAPI(e) {
+  const { url, payloadKey, payloadValue, callback } = e.target.dataset
+  const data = await axios(url).then(response => response.data)
+  customCallbackLibrary[callback]({ data, element: e.target })
+}
+
+export function api() {
+  const apiTriggers = [...document.querySelectorAll('.api')]
+  apiTriggers.forEach(trigger => trigger.addEventListener('click', callAPI))
+}

--- a/public/javascripts/modules/customAPICallbacks.js
+++ b/public/javascripts/modules/customAPICallbacks.js
@@ -1,0 +1,16 @@
+export const customCallbackLibrary = {
+  updateLockIcon: (options) => {
+    const { data: bit, element } = options
+    const lockIcon = element.closest('.lock-item')
+    const openLock = lockIcon.querySelector('.lock-open')
+    const closedLock = lockIcon.querySelector('.lock-closed')
+    
+    if (bit.privacy === 'world') {
+      openLock.classList.remove('hidden')
+      closedLock.classList.add('hidden')
+    } else {
+      openLock.classList.add('hidden')
+      closedLock.classList.remove('hidden')
+    }
+  }
+}

--- a/public/javascripts/modules/editorHelpers.js
+++ b/public/javascripts/modules/editorHelpers.js
@@ -34,8 +34,5 @@ export function deleteWarning() {
 
 export function changePrivacy() {
   const lockBtns = [...document.querySelectorAll('.lock-item')]
-
-  lockBtns.forEach(btn => {
-    btn.addEventListener('click', e => btn.nextSibling.classList.toggle('hidden'))
-  })
+  lockBtns.forEach(btn => btn.addEventListener('click', () => btn.querySelector('.dropdown').classList.toggle('hidden')))
 }

--- a/public/javascripts/modules/editorHelpers.js
+++ b/public/javascripts/modules/editorHelpers.js
@@ -3,10 +3,6 @@ function autosize(el){
   el.style.height = `${el.scrollHeight}px`
 }
 
-function onFocus(el) {
-
-}
-
 export function expandTextArea() {
   const textareas = [...document.querySelectorAll('textarea')];
 
@@ -38,26 +34,8 @@ export function deleteWarning() {
 
 export function changePrivacy() {
   const lockBtns = [...document.querySelectorAll('.lock-item')]
-  const privacyToggle = document.querySelector('#privacy-toggle')
-  const privacyForm = document.querySelector('#privacy-form')
 
-  if (!privacyToggle) return
   lockBtns.forEach(btn => {
-    btn.addEventListener('click', e => {
-      privacyToggle.parentNode.classList.toggle('hidden')
-    })
-  })
-
-  privacyToggle.addEventListener('change', e => {
-     privacyForm.value = e.target.value
-     privacyToggle.parentNode.classList.toggle('hidden')
-
-     if (privacyForm.value !== 'world') {
-       document.querySelector('.lock-open').classList.add('hidden')
-       document.querySelector('.lock-closed').classList.remove('hidden')
-     } else {
-       document.querySelector('.lock-open').classList.remove('hidden')
-       document.querySelector('.lock-closed').classList.add('hidden')
-     }
+    btn.addEventListener('click', e => btn.nextSibling.classList.toggle('hidden'))
   })
 }

--- a/public/sass/partials/_dropdown.css
+++ b/public/sass/partials/_dropdown.css
@@ -1,0 +1,18 @@
+.dropdown {
+  top: 100%;
+  right: 0;
+  z-index: 1;
+  font-size: .7em;
+  flex-wrap: wrap;
+  background: $maize;
+  border-radius: 5px;
+  font-family: $primary-font;
+
+  li {
+    min-width: 150px;
+
+    &:hover {
+      background: $cerulean-frost;
+    }
+  }
+}

--- a/public/sass/partials/_flex.scss
+++ b/public/sass/partials/_flex.scss
@@ -3,6 +3,11 @@
   flex-direction: row;
 }
 
+.flex-container-row-reverse {
+  display: flex;
+  flex-direction: row-reverse;
+}
+
 .flex-container-column {
   display: flex;
   flex-direction: column;

--- a/public/sass/partials/_layout.scss
+++ b/public/sass/partials/_layout.scss
@@ -34,9 +34,3 @@ body {
 .relative {
   position: relative;
 }
-
-.dropdown {
-  left: 10px;
-  top: 100%;
-  z-index: 1;
-}

--- a/public/sass/partials/_spacers.scss
+++ b/public/sass/partials/_spacers.scss
@@ -1,6 +1,7 @@
 $spaced-lg: 20px;
 $spaced-md: 15px;
 $spaced-sm: 10px;
+$spaced-xs: 5px;
 
 .no-mobile-side-margin {
 
@@ -75,6 +76,44 @@ $spaced-sm: 10px;
 
 .pad {
 
+  &.pad-top {
+
+    &.pad-lg {
+      padding-top: $spaced-lg;
+    }
+
+    &.pad-md {
+      padding-top: $spaced-md;
+    }
+
+    &.pad-sm {
+      padding-top: $spaced-sm;
+    }
+
+    &.pad-xs {
+      padding-top: $spaced-xs;
+    }
+  }
+
+  &.pad-bottom {
+
+    &.pad-lg {
+      padding-bottom: $spaced-lg;
+    }
+
+    &.pad-md {
+      padding-bottom: $spaced-md;
+    }
+
+    &.pad-sm {
+      padding-bottom: $spaced-sm;
+    }
+
+    &.pad-xs {
+      padding-bottom: $spaced-xs;
+    }
+  }
+
   &.pad-left {
 
     &.pad-lg {
@@ -87,6 +126,10 @@ $spaced-sm: 10px;
 
     &.pad-sm {
       padding-left: $spaced-sm;
+    }
+
+    &.pad-xs {
+      padding-left: $spaced-xs;
     }
   }
 
@@ -102,6 +145,10 @@ $spaced-sm: 10px;
 
     &.pad-sm {
       padding-right: $spaced-sm;
+    }
+
+    &.pad-xs {
+      padding-right: $spaced-xs;
     }
   }
 }

--- a/public/sass/partials/_variables.scss
+++ b/public/sass/partials/_variables.scss
@@ -12,6 +12,7 @@ $alice-blue: rgba(239, 245, 252, 1);
 $cerulean-frost: rgba(109, 157, 197, 1);
 $maize: rgba(255, 236, 94, 1);
 $eerie-black: rgba(12, 21, 25, 1);
+$white: #fff;
 
 $primary-font: "Playfair Display";
 $secondary-font: "Source Sans Pro";

--- a/public/sass/style.scss
+++ b/public/sass/style.scss
@@ -9,3 +9,4 @@
 @import 'partials/button';
 @import 'partials/navigation';
 @import 'partials/masonry';
+@import 'partials/dropdown';

--- a/views/bit.pug
+++ b/views/bit.pug
@@ -12,7 +12,7 @@ block content
           if user && bit.author.equals(user._id)
             a(class="icon flex-container-row justify-center align-items-center" href=`/bits/${bit._id}/edit`)
               != h.icon('pencil')
-            +privacy(bit.privacy)
+            +privacy(bit)
           if user && (user.id !== bit.author.id)
             +trustedUser(bit, user)
         h1.flex-container-row.justify-center.txt-center= bit.name

--- a/views/bit.pug
+++ b/views/bit.pug
@@ -12,7 +12,7 @@ block content
           if user && bit.author.equals(user._id)
             a(class="icon flex-container-row justify-center align-items-center" href=`/bits/${bit._id}/edit`)
               != h.icon('pencil')
-            +lock(bit.privacy, { hideToggle: true })
+            +privacy(bit.privacy)
           if user && (user.id !== bit.author.id)
             +trustedUser(bit, user)
         h1.flex-container-row.justify-center.txt-center= bit.name

--- a/views/mixins/_bitCard.pug
+++ b/views/mixins/_bitCard.pug
@@ -3,13 +3,9 @@ include _privacy
 
 mixin bitCard(bit = {}, user = {})
   .bit.brick.shaded
-    if bit.privacy === 'trustedUsers'
-      div ✅ Trusted!
-    else if bit.privacy === 'world'
-      div 🌎 Public!
-    else 
-      div 👁️ Only you
-    +privacy(bit)
+    if user && bit.author.id === user.id
+      div.flex-container-row-reverse
+        +privacy(bit)
     div.flex-container-row.align-items-center.justify-center
       h2.flex-container-row.txt-center
         a( href=`../bit/${bit.slug}`) #{bit.name}

--- a/views/mixins/_bitCard.pug
+++ b/views/mixins/_bitCard.pug
@@ -1,4 +1,5 @@
 include _trustedUser
+include _privacy
 
 mixin bitCard(bit = {}, user = {})
   .bit.brick.shaded
@@ -8,6 +9,7 @@ mixin bitCard(bit = {}, user = {})
       div 🌎 Public!
     else 
       div 👁️ Only you
+    +privacy(bit)
     div.flex-container-row.align-items-center.justify-center
       h2.flex-container-row.txt-center
         a( href=`../bit/${bit.slug}`) #{bit.name}

--- a/views/mixins/_bitForm.pug
+++ b/views/mixins/_bitForm.pug
@@ -13,6 +13,5 @@ mixin bitForm(bit = {}, options = { submit: ''})
           textarea(id="bit-content" class=`${options.content}` name="content" placeholder="Write your bit here.")= bit.content
         div
           textarea.hidden(id="prompt-submit" name="prompt")
-        input.hidden(id="privacy-form" name="privacy" value=`${bit.privacy || 'onlyMe'}`)
         div.flex-container-column.align-items-center.spaced.spaced-top.spaced-lg
           button(type="submit" value="Save" class=`button ${options.submit}` ) Save

--- a/views/mixins/_editIcons.pug
+++ b/views/mixins/_editIcons.pug
@@ -1,4 +1,4 @@
 mixin editIcons(bit = {})
-  +privacy(bit.privacy)
+  +privacy(bit)
   div(class="icon delete flex-container-row justify-center align-items-center" data-link=`/bit/delete/${bit._id}`)
     != h.icon('trash-can')

--- a/views/mixins/_lock.pug
+++ b/views/mixins/_lock.pug
@@ -1,19 +1,17 @@
 mixin lock(bit = {}, options = { hideToggle: false })
-  div(class=`icon lock relative flex-container-row justify-center align-items-center`)
-    if bit.privacy === 'world'
-      div(class=`lock-item lock-open flex-container-row justify-center align-items-center ${bit.privacy != 'world' ? 'hidden' : ''}`)
-        != h.icon('lock-open')
-    else 
-      div(class=`lock-item lock-closed flex-container-row justify-center align-items-center ${bit.privacy != 'world' ? '' : 'hidden'}`)
-        != h.icon('lock-closed')
+  div(class=`icon lock lock-item relative flex-container-row justify-center align-items-center`)
+    div(class=`lock-open flex-container-row justify-center align-items-center ${bit.privacy != 'world' ? 'hidden' : ''}`)
+      != h.icon('lock-open')
+    div(class=`lock-closed flex-container-row justify-center align-items-center ${bit.privacy != 'world' ? '' : 'hidden'}`)
+      != h.icon('lock-closed')
     ul.flex-container-row.justify-center.align-items-center.absolute.txt-center.dropdown.hidden
       li.pad.pad-top.pad-bottom.pad-left.pad-right.pad-xs
-        a.flex-container-row.justify-center.align-items.center(href=`/bit/privacy/update/${bit.slug}/onlyMe`)
+        div.api.flex-container-row.justify-center.align-items.center(data-url=`/bit/privacy/update/${bit.slug}/onlyMe` data-payload-key="privacy" data-payload-value="onlyMe" data-callback="updateLockIcon")
           != `👁️ Only you`
-      li.pad.pad-top.pad-bottom.pad-left.pad-right.pad-xs
-        a.flex-container-row.justify-center.align-items.center(href=`/bit/privacy/update/${bit.slug}/trustedUsers`)
+      li.api.pad.pad-top.pad-bottom.pad-left.pad-right.pad-xs
+        div.flex-container-row.justify-center.align-items.center(data-url=`/bit/privacy/update/${bit.slug}/trustedUsers` data-payload-key="privacy" data-payload-value="trustedUsers" data-callback="updateLockIcon")
           != `✅ Trusted Users`
-      li.pad.pad-top.pad-bottom.pad-left.pad-right.pad-xs
-        a.flex-container-row.justify-center.align-items.center(href=`/bit/privacy/update/${bit.slug}/world`)
+      li.api.pad.pad-top.pad-bottom.pad-left.pad-right.pad-xs
+        div.flex-container-row.justify-center.align-items.center(data-url=`/bit/privacy/update/${bit.slug}/world` data-payload-key="privacy" data-payload-value="world" data-callback="updateLockIcon")
           != `🌎 Public`
         

--- a/views/mixins/_lock.pug
+++ b/views/mixins/_lock.pug
@@ -1,13 +1,19 @@
-mixin lock(privacySetting = 'trustedUsers', options = { hideToggle: false })
-  abbr(title=`This is a ${privacySetting != 'world' ? ' private ' : ' public '} bit. It will display for ${privacySetting != 'world' ? 'you and your trusted friends.' : 'everyone.'} To change your privacy settings, go to the Edit page.`)
-    div(class=`icon lock relative flex-container-row justify-center align-items-center`)
-      div(class=`lock-item lock-closed flex-container-row justify-center align-items-center ${privacySetting != 'world' ? '' : 'hidden'}`)
-        != h.icon('lock-closed')
-      div(class=`lock-item lock-open flex-container-row justify-center align-items-center ${privacySetting != 'world' ? 'hidden' : ''}`)
+mixin lock(bit = {}, options = { hideToggle: false })
+  div(class=`icon lock relative flex-container-row justify-center align-items-center`)
+    if bit.privacy === 'world'
+      div(class=`lock-item lock-open flex-container-row justify-center align-items-center ${bit.privacy != 'world' ? 'hidden' : ''}`)
         != h.icon('lock-open')
-      if !options.hideToggle
-        div.absolute.dropdown.hidden
-          select(id="privacy-toggle" value=`${privacySetting}`)
-            option(value="trustedUsers" selected=privacySetting === 'trustedUsers') Trusted Users
-            option(value="onlyMe" selected=privacySetting === 'onlyMe') Only Me
-            option(value="world" selected=privacySetting === 'world') Public
+    else 
+      div(class=`lock-item lock-closed flex-container-row justify-center align-items-center ${bit.privacy != 'world' ? '' : 'hidden'}`)
+        != h.icon('lock-closed')
+    ul.flex-container-row.justify-center.align-items-center.absolute.txt-center.dropdown.hidden
+      li.pad.pad-top.pad-bottom.pad-left.pad-right.pad-xs
+        a.flex-container-row.justify-center.align-items.center(href=`/bit/privacy/update/${bit.slug}/onlyMe`)
+          != `👁️ Only you`
+      li.pad.pad-top.pad-bottom.pad-left.pad-right.pad-xs
+        a.flex-container-row.justify-center.align-items.center(href=`/bit/privacy/update/${bit.slug}/trustedUsers`)
+          != `✅ Trusted Users`
+      li.pad.pad-top.pad-bottom.pad-left.pad-right.pad-xs
+        a.flex-container-row.justify-center.align-items.center(href=`/bit/privacy/update/${bit.slug}/world`)
+          != `🌎 Public`
+        

--- a/views/mixins/_privacy.pug
+++ b/views/mixins/_privacy.pug
@@ -1,4 +1,4 @@
 include _lock
 
-mixin privacy(privacySetting, options = { hide: false }) 
-  +lock(privacySetting)
+mixin privacy(bit, options = { hide: false }) 
+  +lock(bit)


### PR DESCRIPTION
This is cool -- the privacy toggle is now a cool dropdown, maize colored, that lets a user click on a privacy setting, quickly setting their privacy settings without reloading the page. Cool!

Also adds a couple API functions that I can use in the future for similar interactions, and a custom callbacks library that should be extendible.